### PR TITLE
Applied correct use of new scoring (rolling out to end of turn first)…

### DIFF
--- a/ScriptsOfTribute-Core/Bots/src/MaltheMCTS/Node.cs
+++ b/ScriptsOfTribute-Core/Bots/src/MaltheMCTS/Node.cs
@@ -139,7 +139,6 @@ public class Node
             case ScoringMethod.RolloutTurnsCompletionsThenHeuristic:
                 return RolloutTillTurnsEndThenHeuristic(Bot.Settings.ROLLOUT_TURNS_BEFORE_HEURISTIC);
             case ScoringMethod.MaltheScoring:
-                return HeuristicScoring.Score(gameState, Bot.Settings.MANUAL_MODEL);
                 var gameState = RollOutTillEndOfTurn();
                 return HeuristicScoring.Score(gameState, Bot.Settings.FEATURE_SET_MODEL_TYPE);
             default:


### PR DESCRIPTION
… and fixed bug in old version, where the possible moves of the node is being modified when modifing the rolloutpossiblemoves